### PR TITLE
Fix : Blank member name in Attachment Report

### DIFF
--- a/install/senayan.sql
+++ b/install/senayan.sql
@@ -1449,7 +1449,7 @@ CREATE TABLE `files_read` (
   `filelog_id` int(11) NOT NULL AUTO_INCREMENT,
   `file_id` int(11) NOT NULL,
   `date_read` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP,
-  `member_id` int(11) DEFAULT NULL,
+  `member_id` varchar(20) DEFAULT NULL,
   `user_id` int(11) DEFAULT NULL,
   `client_ip` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`filelog_id`)


### PR DESCRIPTION
member_id is not always use number format, sometimes it's combined with string, dots etc.