### PR TITLE
Add : Escape string in publish year

### DIFF
--- a/admin/modules/system/biblio_indexer.inc.php
+++ b/admin/modules/system/biblio_indexer.inc.php
@@ -139,7 +139,7 @@ class biblio_indexer
           $data['publish_place'] = $this->obj_db->escape_string($rb_id['publish_place']);
           $data['isbn_issn'] = $this->obj_db->escape_string($rb_id['isbn_issn']);
           $data['language'] = $this->obj_db->escape_string($rb_id['language']);
-          $data['publish_year'] = $rb_id['publish_year'];
+          $data['publish_year'] = $this->obj_db->escape_string($rb_id['publish_year']);
           $data['classification'] = $this->obj_db->escape_string($rb_id['classification']);
           $data['spec_detail_info'] = $this->obj_db->escape_string($rb_id['spec_detail_info']);
           $data['call_number'] = $this->obj_db->escape_string($rb_id['call_number']);


### PR DESCRIPTION
Some data from other system while migration have one quote and make it failed to indexed.