### PR TITLE
Fix : Removing too strict rule

### DIFF
--- a/simbio2/simbio_GUI/form_maker/simbio_form_element.inc.php
+++ b/simbio2/simbio_GUI/form_maker/simbio_form_element.inc.php
@@ -131,7 +131,7 @@ class simbio_fe_select extends abs_simbio_form_element
           $_buffer .= '<option value="'.$option[0].'" '.(in_array($option[0], $this->element_value)?'selected':'').'>';
           $_buffer .= $option[1].'</option>'."\n";
         } else {
-          $_buffer .= '<option value="'.$option[0].'" '.(($option[0] === $this->element_value)?'selected':'').'>';
+          $_buffer .= '<option value="'.$option[0].'" '.(($option[0] == $this->element_value)?'selected':'').'>';
           $_buffer .= $option[1].'</option>'."\n";
         }
       }


### PR DESCRIPTION
It's enough to compare form without needing to compare data types.
Example
1 == '1'; // enough to make option to be selected