### PR TITLE
Prevent clash at require/include same autoload pathname

### DIFF
--- a/sysconfig.inc.php
+++ b/sysconfig.inc.php
@@ -27,35 +27,6 @@ if (!defined('INDEX_AUTH')) {
     die("can not access this file directly");
 }
 
-// Environment config
-require 'config/sysconfig.env.inc.php';
-
-/*
- * Set to development or production
- *
- * In production mode, the system error message will be disabled
- */
-define('ENVIRONMENT', $Environment);
-
-switch (ENVIRONMENT) {
-  case 'development':
-    @error_reporting(-1);
-    @ini_set('display_errors', true);
-    break;
-  case 'production':
-    @ini_set('display_errors', false);
-    @error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
-    break;
-  default:
-    header('HTTP/1.1 503 Service Unavailable.', TRUE, 503);
-    echo 'The application environment is not set correctly.';
-    exit(1); // EXIT_ERROR
-}
-
-// require composer library
-if (file_exists(realpath(dirname(__FILE__)) . '/vendor/autoload.php')) require 'vendor/autoload.php';
-require 'lib/autoload.php';
-
 // use httpOnly for cookie
 @ini_set( 'session.cookie_httponly', true );
 // check if safe mode is on
@@ -80,6 +51,35 @@ define('DS', DIRECTORY_SEPARATOR);
 
 // senayan base dir
 define('SB', realpath(dirname(__FILE__)).DS);
+
+// Environment config
+require SB . 'config/sysconfig.env.inc.php';
+
+/*
+ * Set to development or production
+ *
+ * In production mode, the system error message will be disabled
+ */
+define('ENVIRONMENT', $Environment);
+
+switch (ENVIRONMENT) {
+  case 'development':
+    @error_reporting(-1);
+    @ini_set('display_errors', true);
+    break;
+  case 'production':
+    @ini_set('display_errors', false);
+    @error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
+    break;
+  default:
+    header('HTTP/1.1 503 Service Unavailable.', TRUE, 503);
+    echo 'The application environment is not set correctly.';
+    exit(1); // EXIT_ERROR
+}
+
+// require composer library
+if (file_exists(SB . 'vendor/autoload.php')) require SB . 'vendor/autoload.php';
+require SB . 'lib/autoload.php';
 
 // absolute path for simbio platform
 define('SIMBIO', SB.'simbio2'.DS);
@@ -760,7 +760,7 @@ $sysconf['max_insert_batch'] = 100;
 $sysconf['load_balanced_env'] = false;
 
 // load helper
-require_once "lib/helper.inc.php";
+require_once SB . "lib/helper.inc.php";
 
 // load all Plugins
 \SLiMS\Plugins::getInstance()->loadPlugins();


### PR DESCRIPTION
There are require/include file without parent directory path ("SB") in sysconfig.inc.php , 

e.g: 
require 'config/sysconfig.env.inc.php';
require 'vendor/autoload.php'
require 'lib/autoload.php'; 
require_once "lib/helper.inc.php";

In some case, there are custom SLiMS admin module/plugin need to use other autoload with same path ("lib/autoload.php") like this:
.....

if (!defined('SB')) {
    // in sysconfig.inc.php, autoload.php require without root path
    include '../../../sysconfig.inc.php'; // and this module there are autoload.php too in lib/autoload.php.
    // sysconfig.inc.php will be include lib/autoload.php at this module not at <slims_root>/lib/autoload.php,
    // then error will be appearance eg: "class \SLiMS\Plugins not found etc."
    // start the session
    require SB.'admin/default/session.inc.php';
}

// custom autoload.php
require __DIR__ . '/lib/autoload.php';