### PR TITLE
Fix CAPTCHA that is not showing in 9.5.2

### DIFF
--- a/config/csp.php
+++ b/config/csp.php
@@ -9,7 +9,7 @@
  */
 return [
     "base-uri 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+
     "style-src 'self' 'unsafe-inline' *.bootstrapcdn.com *.googleapis.com",
     "img-src 'self' data:",
     "connect-src 'self' kutipan.herokuapp.com",


### PR DESCRIPTION
Google's new reCAPTCHA v2 doesn't require any CSP (Content Security Policy) regarding script-src.