### PR TITLE
Sanitize order parameters to prevent SQL injection (fix #281)

### DIFF
--- a/admin/modules/master_file/author.php
+++ b/admin/modules/master_file/author.php
@@ -311,7 +311,12 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
 
     // change the record order
     if (isset($_GET['fld']) AND isset($_GET['dir'])) {
-        $datagrid->setSQLorder("'".urldecode($dbs->escape_string($_GET['fld']))."' ".$dbs->escape_string($_GET['dir']));
+      $allowed_fields = array('author_name','author_year','authority_type','auth_list','last_update','author_id');
+    $fld = $_GET['fld'];
+    $dir = strtoupper($_GET['dir']);
+    if (in_array($fld, $allowed_fields) && in_array($dir, array('ASC','DESC'))) {
+        $datagrid->setSQLorder($fld . ' ' . $dir);
+}   //$datagrid->setSQLorder("'".urldecode($dbs->escape_string($_GET['fld']))."' ".$dbs->escape_string($_GET['dir']));
     }
 
     // is there any search


### PR DESCRIPTION
This commit fixes a critical SQL injection vulnerability in admin/modules/master_file/author.php. The previous implementation passed unsanitized query parameters 'fld' and 'dir' directly to setSQLorder, allowing attackers to manipulate the ORDER BY clause. The new implementation introduces a whitelist of allowed fields and directions ('ASC' and 'DESC'), validates user input against these lists, and only sets the SQL order if both parameters are valid. The vulnerable call has been commented out. This addresses issue #281.