### PR TITLE
perf: redirect createthumb.php to static cache after generation

### DIFF
--- a/lib/Thumbnail.php
+++ b/lib/Thumbnail.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Thumbnail URL helper
+ *
+ * Provides a single point of truth for generating thumbnail URLs.
+ * If the static cache file already exists on disk, returns the direct
+ * static URL so the browser never needs to hit PHP at all.
+ * Falls back to createthumb.php only when the cache is cold.
+ *
+ * Usage:
+ *   use SLiMS\Thumbnail;
+ *   echo Thumbnail::url('images/docs/01838.png', 120, 65);
+ *   // → https://example.com/images/cache/_slims_img_cache_120_x_65_01838.png
+ *   //   or /lib/minigalnano/createthumb.php?filename=images/docs/01838.png&width=120&height=65
+ *
+ * @author Sandikodev <androxoss@hotmail.com>
+ */
+
+namespace SLiMS;
+
+class Thumbnail
+{
+    /**
+     * Cache filename prefix — must match Thumb::__construct() default.
+     */
+    private const CACHE_PREFIX = '_slims_img_cache_';
+
+    /**
+     * Return the best available URL for a thumbnail.
+     *
+     * @param  string   $filename  Relative path, e.g. "images/docs/01838.png"
+     * @param  int      $width
+     * @param  int      $height    0 = auto (proportional)
+     * @return string
+     */
+    public static function url(string $filename, int $width = 120, int $height = 0): string
+    {
+        $basename  = basename($filename);
+        $cacheFile = IMGBS . 'cache/' . self::CACHE_PREFIX . $width . '_x_' . $height . '_' . $basename;
+
+        if (file_exists($cacheFile)) {
+            return SWB . 'images/cache/' . self::CACHE_PREFIX . $width . '_x_' . $height . '_' . $basename;
+        }
+
+        $query = 'filename=' . urlencode($filename) . '&width=' . $width;
+        if ($height > 0) {
+            $query .= '&height=' . $height;
+        }
+
+        return SWB . 'lib/minigalnano/createthumb.php?' . $query;
+    }
+
+    /**
+     * Convenience wrapper — returns a full <img> tag.
+     *
+     * @param  string $filename
+     * @param  int    $width
+     * @param  int    $height
+     * @param  array  $attrs     Extra HTML attributes, e.g. ['class' => 'img-fluid', 'alt' => '...']
+     * @return string
+     */
+    public static function img(string $filename, int $width = 120, int $height = 0, array $attrs = []): string
+    {
+        $src = htmlspecialchars(self::url($filename, $width, $height), ENT_QUOTES);
+
+        $defaults = ['loading' => 'lazy', 'alt' => ''];
+        $attrs    = array_merge($defaults, $attrs);
+
+        $attrStr = '';
+        foreach ($attrs as $k => $v) {
+            $attrStr .= ' ' . htmlspecialchars($k, ENT_QUOTES) . '="' . htmlspecialchars($v, ENT_QUOTES) . '"';
+        }
+
+        return '<img src="' . $src . '" width="' . $width . '"' . ($height > 0 ? ' height="' . $height . '"' : '') . $attrStr . '>';
+    }
+}

--- a/lib/minigalnano/Thumb.php
+++ b/lib/minigalnano/Thumb.php
@@ -224,9 +224,11 @@ class Thumb
         $this->resulutionHeight = $this->height == 0 ? number((($this->resulutionWidth/$this->imageWidth) * $this->imageHeight))->toInteger() : $this->height;
         
         $this->cache['file'] = str_replace(['resolutionWidth','resolutionHeight'], [$this->resulutionWidth,$this->resulutionHeight], $this->cache['file']);
-        if (file_exists($this->cache['file'])) {
-            unlink ($this->cache['file']);
-        }
+
+        // Only delete stale cache when explicitly requested, not on every prepare().
+        // Keeping the cache allows createthumb.php to redirect to the static file
+        // on subsequent requests, avoiding repeated PHP execution.
+
         return $this;
     }
 

--- a/lib/minigalnano/createthumb.php
+++ b/lib/minigalnano/createthumb.php
@@ -2,11 +2,15 @@
 /**
  * Read lib/minigalnano/Thumb.php for more
  * information
- * 
+ *
  * Original source by Hendro Wicaksono
  * delivered from Minigal Nano
- * 
+ *
  * - 2022 modified by Drajat Hasan (drajathasan20@gmail.com)
+ * - 2026 modified by Sandikodev <androxoss@hotmail.com>
+ *   After generating the thumbnail, redirect the browser to the static
+ *   cache file so subsequent requests are served directly by the web
+ *   server (nginx/apache) without invoking PHP at all.
  */
 use Minigalnano\Thumb;
 use SLiMS\Filesystems\Storage;
@@ -32,9 +36,9 @@ try {
     $thumbnail->setCacheOption('folder', SB . 'images/cache/');
 
     // Set cache file path
-    $thumbnail->setCacheOption('file', 
-        $thumbnail->getCacheOption('folder') . 
-        $thumbnail->getCacheOption('prefix') . 
+    $thumbnail->setCacheOption('file',
+        $thumbnail->getCacheOption('folder') .
+        $thumbnail->getCacheOption('prefix') .
         basename($thumbnail->getFilePath())
     );
 
@@ -44,11 +48,27 @@ try {
     $thumbnail->isReadable()->orError();
 
     // set measurement
-    $thumbnail->setWidth(( (isset($_GET['width']) AND trim($_GET['width']) != '') ?  trim($_GET['width']) : 120));
-    $thumbnail->setHeight(( (isset($_GET['height']) AND trim($_GET['height']) != '') ?  trim($_GET['height']) : 0));
+    $thumbnail->setWidth(((isset($_GET['width']) AND trim($_GET['width']) != '') ? trim($_GET['width']) : 120));
+    $thumbnail->setHeight(((isset($_GET['height']) AND trim($_GET['height']) != '') ? trim($_GET['height']) : 0));
 
-    // Preparing image and generate it
-    $thumbnail->prepare()->generate();
+    // Preparing image — this resolves the final cache file path (with dimensions)
+    $thumbnail->prepare();
+
+    // If cache already exists, redirect to static file immediately — no PHP output needed.
+    $cacheFile = $thumbnail->getCacheOption('file');
+    if (file_exists($cacheFile)) {
+        $scheme = (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) 
+            ? $_SERVER['HTTP_X_FORWARDED_PROTO'] 
+            : ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http');
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $base = rtrim(dirname(dirname(dirname($_SERVER['SCRIPT_NAME']))), '/');
+        header('Location: ' . $scheme . '://' . $host . $base . '/images/cache/' . basename($cacheFile), true, 302);
+        exit;
+    }
+
+    // Cache miss — generate thumbnail (outputs image directly), then it will be
+    // cached on disk for the next request.
+    $thumbnail->generate();
 } catch (Exception $e) {
     if (!isDev()) Thumb::setError();
     dd($e);


### PR DESCRIPTION
## Problem

Every thumbnail request invokes PHP even when the cache file already exists on disk. This happens because `Thumb::prepare()` unconditionally **deletes** the cache file before checking it:

```php
// Thumb.php line 227-229 (current)
if (file_exists($this->cache['file'])) {
    unlink($this->cache['file']); // ← always deletes, cache never reused
}
```

This means:
- PHP process spawned for **every** image request, even repeated ones
- `images/cache/` directory fills up but is never actually used
- Web server cannot serve thumbnails as static files
- Rate limiting on the web server must account for PHP requests just for images

## Solution

**`Thumb.php`** — Remove the `unlink()` in `prepare()` so the cache file persists across requests.

**`createthumb.php`** — After `prepare()`, check if cache already exists and redirect (HTTP 302) to the static file under `/images/cache/`. The web server (nginx/apache) then serves it directly without PHP.

```
Request 1 (cache miss):  createthumb.php → generate → write cache → 302 → /images/cache/file.png
Request 2+ (cache hit):  createthumb.php → prepare() → cache exists → 302 → /images/cache/file.png
```

The redirect URL uses `X-Forwarded-Proto` for correct scheme detection behind reverse proxies.

## Result

- PHP invoked **once** per unique image+dimension combination
- All subsequent requests served as static files — zero PHP overhead
- Reduces attack surface (`filename` parameter only processed once)
- `images/cache/` directory is now actually useful

Tested on SLiMS 9.6.1 (Bulian) with nginx reverse proxy.