### PR TITLE
fix: quote column name \`2fa\` SQL query

### DIFF
--- a/lib/Auth/Methods/Ldap.php
+++ b/lib/Auth/Methods/Ldap.php
@@ -205,7 +205,7 @@ class Ldap extends Native
             $_check_q = DB::query(<<<SQL
             SELECT
                 u.user_id as uid, u.username as uname, u.passwd,
-                u.realname as realname, u.groups, u.user_image as upict, u.2fa
+                u.realname as realname, u.groups, u.user_image as upict, u.`2fa`
                 FROM user AS u
                 WHERE u.username=?
             SQL, [$username]);

--- a/lib/Auth/Methods/Native.php
+++ b/lib/Auth/Methods/Native.php
@@ -87,7 +87,7 @@ class Native extends Contract
         $user = DB::query(<<<SQL
         SELECT
             u.user_id as uid, u.username as uname, u.passwd,
-            u.realname as realname, u.groups, u.user_image as upict, u.2fa
+            u.realname as realname, u.groups, u.user_image as upict, u.`2fa`
             FROM user AS u
             WHERE u.username=?
         SQL, [$this->username]);

--- a/lib/Auth/Validator.php
+++ b/lib/Auth/Validator.php
@@ -175,7 +175,7 @@ class Validator
         }
 
         $sql = 'SELECT u.user_id AS uid, u.username AS uname, u.passwd, 
-                       u.realname AS realname, u.groups, u.user_image AS upict, u.2fa
+                       u.realname AS realname, u.groups, u.user_image AS upict, u.`2fa`
             FROM user AS u
             INNER JOIN user_tokens AS ut ON ut.user_id = u.user_id
             WHERE ut.selector = :selector AND ut.expires_at > now()
@@ -196,7 +196,7 @@ class Validator
     function findUserByUsername($username): array
     {
         $sql = 'SELECT u.user_id AS uid, u.username AS uname, u.passwd, 
-                u.realname AS realname, u.groups, u.user_image AS upict, u.2fa 
+                u.realname AS realname, u.groups, u.user_image AS upict, u.`2fa` 
                 FROM user AS u WHERE u.username = :username';
 
         $statement = DB::getInstance()->prepare($sql);

--- a/lib/admin_logon.inc.php
+++ b/lib/admin_logon.inc.php
@@ -258,7 +258,7 @@ class admin_logon
         */
         $_sql_librarian_login = sprintf("SELECT
             u.user_id, u.username, u.passwd,
-            u.realname, u.groups, u.user_image, u.2fa
+            u.realname, u.groups, u.user_image, u.`2fa`
             FROM user AS u
             WHERE u.username='%s'", $this->obj_db->escape_string($this->username));
         $_user_q = $this->obj_db->query($_sql_librarian_login);
@@ -299,7 +299,7 @@ class admin_logon
     protected function nativeLoginMd5() {
         $_sql_librarian_login = sprintf("SELECT
             u.user_id, u.username,
-            u.realname, u.groups, u.2fa
+            u.realname, u.groups, u.`2fa`
             FROM user AS u
             WHERE u.username='%s'
                 AND u.passwd=MD5('%s')", $this->obj_db->escape_string($this->username), $this->obj_db->escape_string($this->password));


### PR DESCRIPTION
Unquoted column name \`2fa\` causes SQL syntax error on MariaDB because the parser interprets \`u.2fa\` as numeric literal \`2\` followed by identifier \`fa\` when using dot-notation. Wrapping with backticks resolves the ambiguity.