### PR TITLE
Add Dual Label (Spine label and Barcode) Print Plugin (dual_label_print.plugin.php)

### DIFF
--- a/plugins/dual-label/dual_label_print.plugin.php
+++ b/plugins/dual-label/dual_label_print.plugin.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Plugin Name: Dual Label Print - Apu
+ * Plugin URI: https://github.com/nalamapu/dual_label_print_apu/
+ * Description: Print spine label + barcode label together (per item) from a single accession number search. Each item produces two 38×25 mm stickers: spine label first, then barcode label.
+ * Version: 1.0.0
+ * Author: Nurul Alam Apu
+ * Author URI: https://www.slimsbd.com
+ * WhatsApp: +8801674066064
+ * Email: slimsbd@gmail.com
+ */
+
+$plugin = \SLiMS\Plugins::getInstance();
+$plugin->registerMenu('bibliography', 'Dual Label Print - Apu', __DIR__ . '/index.php');


### PR DESCRIPTION
This plugin allows printing spine and barcode labels together from a single accession number search, generating two stickers per item.